### PR TITLE
Fix the mapping of auto points back to x,y

### DIFF
--- a/examples/rand.rs
+++ b/examples/rand.rs
@@ -26,6 +26,11 @@ fn main() {
     }
     let spline = spec.solve();
     let path = spline.render();
+    let mut auto_pts = Vec::new();
+    for seg in spline.segments() {
+        auto_pts.push(seg.p1);
+        auto_pts.push(seg.p2);
+    }
     println!(
         r##"<!DOCTYPE html>
 <html>
@@ -38,6 +43,12 @@ fn main() {
     for pt in &pts {
         println!(
             r#"      <circle cx="{}" cy="{}", r="3", fill="blue" />"#,
+            pt.x, pt.y
+        )
+    }
+    for pt in &auto_pts {
+        println!(
+            r##"      <circle cx="{}" cy="{}", r="3", fill="#88c" />"##,
             pt.x, pt.y
         )
     }

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -451,11 +451,11 @@ impl Segment {
         let v = p3 - p0;
         let a = Affine::new([v.x, v.y, -v.y, v.x, p0.x, p0.y]);
         let p1 = p1.unwrap_or_else(|| {
-            let p1 = HyperBezier::v_for_params(-th0, hb.bias0).to_point();
+            let p1 = HyperBezier::v_for_params(th0, hb.bias0).to_point();
             a * p1
         });
         let p2 = p2.unwrap_or_else(|| {
-            let p2 = Point::new(1.0, 0.0) - HyperBezier::v_for_params(th1, hb.bias1);
+            let p2 = Point::new(1.0, 0.0) - HyperBezier::v_for_params(-th1, hb.bias1);
             a * p2
         });
         let k_scale = v.hypot().recip();


### PR DESCRIPTION
The signs of th0 and th1 were reversed, which is an easy enough mistake
to make because I think they're flipped somewhere in the hyperbezier.

Also adds crude visualization of those points to the rand example.