### PR TITLE
Make SplineSpec reusable

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -60,7 +60,7 @@ fn subpath_to_spline(p: &Subpath) -> Spline {
         }
         spec.close();
     }
-    spec.solve()
+    spec.solve().into_owned()
 }
 
 fn path_to_splines(p: &Path) -> Vec<Spline> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,6 @@ mod simple_spline;
 mod spline;
 mod util;
 
+pub use crate::spline::{Element, Segment, Spline, SplineSpec};
 pub use hyperbezier::{HyperBezier, ThetaParams};
 pub use simple_spline::SimpleSpline;
-pub use crate::spline::{Segment, Spline, SplineSpec};


### PR DESCRIPTION
Currently, generating a Spline from a SplineSpec consumes
the SplineSpec, moving the segments in to the Spline.

With this change, the Spline now borrows the segments, although
it can easily take ownership via Spline::into_owned. The SplineSpec
can then be modified, either by adding existing elements or by
mutating elements in place.

The latter option should be done with care, as it could allow
the elements to be put in an invalid state.

The motivation here is to allow efficient updating of the spline,
such as in an interactive editing tool.