### PR TITLE
Add serde feature, add serialization of SplineSpec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,17 @@ categories = ["graphics"]
 
 [dependencies]
 kurbo = "0.7"
+serde_ = { version = "1.0.117", package="serde", features = ["derive"], optional = true }
 
 [dev-dependencies]
 rand = "0.7"
-serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
+
+[features]
+serde = ["serde_", "kurbo/serde"]
+
+
+[[example]]
+name = "json"
+required-features = ["serde"]
+

--- a/paths/u.json
+++ b/paths/u.json
@@ -1,15 +1,53 @@
-{"subpaths": [
-    {
-        "pts": [
-            {"OnCurve":[50.0, 50.0, true]},
-            {"OnCurve":[50.0, 225.0, true]},
-            {"Auto": null},
-            {"Auto": null},
-            {"OnCurve":[200.0, 400.0, true]},
-            {"Auto": null},
-            {"Auto": null},
-            {"OnCurve":[350.0, 225.0, true]},
-            {"OnCurve":[350.0, 50.0, true]}
-        ]}
-    
-]}
+[
+  {
+    "elements": [
+      {
+        "MoveTo": {
+          "x": 50.0,
+          "y": 50.0
+        }
+      },
+      {
+        "LineTo": [
+          {
+            "x": 50.0,
+            "y": 225.0
+          },
+          true
+        ]
+      },
+      {
+        "SplineTo": [
+          null,
+          null,
+          {
+            "x": 200.0,
+            "y": 400.0
+          },
+          true
+        ]
+      },
+      {
+        "SplineTo": [
+          null,
+          null,
+          {
+            "x": 350.0,
+            "y": 225.0
+          },
+          true
+        ]
+      },
+      {
+        "LineTo": [
+          {
+            "x": 350.0,
+            "y": 50.0
+          },
+          true
+        ]
+      }
+    ],
+    "is_closed": false
+  }
+]

--- a/paths/u2.json
+++ b/paths/u2.json
@@ -1,15 +1,56 @@
-{"subpaths": [
-    {
-        "pts": [
-            {"OnCurve":[50.0, 50.0, true]},
-            {"OnCurve":[50.0, 225.0, true]},
-            {"Auto": null},
-            {"OffCurve": [75, 400]},
-            {"OnCurve":[200.0, 400.0, true]},
-            {"Auto": null},
-            {"Auto": null},
-            {"OnCurve":[350.0, 225.0, true]},
-            {"OnCurve":[350.0, 50.0, true]}
-        ]}
-    
-]}
+[
+  {
+    "elements": [
+      {
+        "MoveTo": {
+          "x": 50.0,
+          "y": 50.0
+        }
+      },
+      {
+        "LineTo": [
+          {
+            "x": 50.0,
+            "y": 225.0
+          },
+          true
+        ]
+      },
+      {
+        "SplineTo": [
+          null,
+          {
+            "x": 75.0,
+            "y": 400.0
+          },
+          {
+            "x": 200.0,
+            "y": 400.0
+          },
+          true
+        ]
+      },
+      {
+        "SplineTo": [
+          null,
+          null,
+          {
+            "x": 350.0,
+            "y": 225.0
+          },
+          true
+        ]
+      },
+      {
+        "LineTo": [
+          {
+            "x": 350.0,
+            "y": 50.0
+          },
+          true
+        ]
+      }
+    ],
+    "is_closed": false
+  }
+]

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -1,7 +1,10 @@
 //! A general purpose spline with explicit control.
 
-use kurbo::{Affine, BezPath, Point, Vec2};
 use std::borrow::Cow;
+
+use kurbo::{Affine, BezPath, Point, Vec2};
+#[cfg(feature = "serde")]
+use serde_::{Deserialize, Serialize};
 
 use crate::hyperbezier::{self, HyperBezier, ThetaParams};
 use crate::simple_spline;
@@ -11,6 +14,11 @@ use crate::util;
 ///
 /// Currently this represents a single subpath.
 #[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_")
+)]
 pub struct SplineSpec {
     elements: Vec<Element>,
     is_closed: bool,
@@ -18,12 +26,21 @@ pub struct SplineSpec {
     ///
     /// There is one of these for each smooth on-curve point with an auto
     /// point on both sides.
+    #[cfg_attr(feature = "serde", serde(skip))]
     ths: Vec<f64>,
+    #[cfg_attr(feature = "serde", serde(skip))]
     dths: Vec<f64>,
     /// The tentative solution.
+    #[cfg_attr(feature = "serde", serde(skip))]
     segments: Vec<Segment>,
     /// `true` if the inputs have changed, and the spline needs to be solved.
+    #[cfg_attr(feature = "serde", serde(skip, default = "serde_true"))]
     dirty: bool,
+}
+
+#[cfg(feature = "serde")]
+fn serde_true() -> bool {
+    true
 }
 
 /// A solved spline.
@@ -57,6 +74,11 @@ pub struct Segment {
 
 /// An imperative description of a spline path.
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_")
+)]
 pub enum Element {
     /// The start of a spline path.
     MoveTo(Point),
@@ -478,7 +500,7 @@ impl Element {
         }
     }
 
-    fn endpoint(&self) -> Point {
+    pub fn endpoint(&self) -> Point {
         match self {
             Element::MoveTo(p) => *p,
             Element::LineTo(p, _) => *p,


### PR DESCRIPTION
The motivation here is to make it easy to generate test cases
for when I'm seeing weird results when using the spline.

As an example: the following looks well-formed to me, but is borked:

```json
[
  {
    "elements": [
      {
        "MoveTo": {
          "x": 100.0,
          "y": 100.0
        }
      },
      {
        "SplineTo": [
          {
            "x": 122.64861940153713,
            "y": 132.6028031358549
          },
          null,
          {
            "x": 200.0,
            "y": 150.0
          },
          true
        ]
      },
      {
        "LineTo": [
          {
            "x": 50.0,
            "y": 200.0
          },
          true
        ]
      },
      {
        "LineTo": [
          {
            "x": 250.0,
            "y": 250.0
          },
          false
        ]
      },
      {
        "SplineTo": [
          null,
          null,
          {
            "x": 300.0,
            "y": 300.0
          },
          false
        ]
      }
    ],
    "is_closed": false
  }
]
```