### PR TITLE
Splinetoy!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,8 @@ serde = ["serde_", "kurbo/serde"]
 name = "json"
 required-features = ["serde"]
 
+[workspace]
+members = ["splinetoy"]
+
+[patch.crates-io]
+druid = { version = "0.6.0", git = "https://github.com/linebender/druid.git", rev = "65eb3060" }

--- a/splinetoy/Cargo.toml
+++ b/splinetoy/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "splinetoy"
+version = "0.1.0"
+authors = ["Colin Rofls <colin@cmyr.net>"]
+edition = "2018"
+
+[dependencies]
+druid = "0.6"
+serde_json = "1.0.60"
+spline = { version = "0.3.0", features=["serde"], path = ".."}

--- a/splinetoy/src/edit_session.rs
+++ b/splinetoy/src/edit_session.rs
@@ -85,7 +85,7 @@ impl EditSession {
         let closest = self.iter_paths().enumerate().fold(None, |acc, (i, path)| {
             let dist = path.nearest_segment_distance(point);
             match acc {
-                Some((cur_idx, cur_dist)) if cur_dist > dist => Some((cur_idx, cur_dist)),
+                Some((cur_idx, cur_dist)) if cur_dist < dist => Some((cur_idx, cur_dist)),
                 _ if dist < MIN_CLICK_DISTANCE => Some((i, dist)),
                 _ => None,
             }

--- a/splinetoy/src/edit_session.rs
+++ b/splinetoy/src/edit_session.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use druid::kurbo::BezPath;
 use druid::{Data, Point, Vec2};
 
 use crate::path::{Path, PointId, SplinePoint};
@@ -29,6 +30,13 @@ impl EditSession {
 
     pub fn iter_paths(&self) -> impl Iterator<Item = &Path> {
         Some(&self.path).into_iter().chain(self.paths.iter())
+    }
+
+    pub fn bezier(&self) -> BezPath {
+        self.iter_paths()
+            .flat_map(|p| p.bezier().elements())
+            .copied()
+            .collect()
     }
 
     pub fn add_point(&mut self, point: Point, smooth: bool) {

--- a/splinetoy/src/edit_session.rs
+++ b/splinetoy/src/edit_session.rs
@@ -32,14 +32,16 @@ impl EditSession {
         self.path.update_for_drag(handle)
     }
 
-    pub fn remove_last_segment(&mut self) {
-        self.selection = self.path.remove_last_segment()
+    pub fn delete(&mut self) {
+        if let Some(selected) = self.selection.take() {
+            self.selection = self.path.delete(selected);
+        }
     }
 
-    pub fn close(&mut self) {
-        self.path.close();
-        self.selection = None;
-    }
+    //pub fn close(&mut self) {
+    //self.path.close();
+    //self.selection = None;
+    //}
 
     pub fn is_selected(&self, id: PointId) -> bool {
         Some(id) == self.selection

--- a/splinetoy/src/edit_session.rs
+++ b/splinetoy/src/edit_session.rs
@@ -1,4 +1,4 @@
-//use std::collections::HashSet;
+use std::sync::Arc;
 
 use druid::{Data, Point, Vec2};
 
@@ -9,7 +9,8 @@ const CLICK_PENALTY: f64 = MIN_CLICK_DISTANCE / 2.0;
 
 #[derive(Clone, Debug, Data)]
 pub struct EditSession {
-    pub path: Path,
+    path: Path,
+    paths: Arc<Vec<Path>>,
     selection: Option<PointId>,
 }
 
@@ -18,11 +19,30 @@ impl EditSession {
         EditSession {
             path: Path::new(),
             selection: None,
+            paths: Arc::new(Vec::new()),
         }
     }
 
+    pub fn active_path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn iter_paths(&self) -> impl Iterator<Item = &Path> {
+        Some(&self.path).into_iter().chain(self.paths.iter())
+    }
+
     pub fn add_point(&mut self, point: Point, smooth: bool) {
-        if !self.path.closed() {
+        if self
+            .path
+            .points()
+            .first()
+            .map(|pt| pt.point.distance(point) < MIN_CLICK_DISTANCE)
+            .unwrap_or(false)
+        {
+            self.path.close(smooth);
+            let path = std::mem::replace(&mut self.path, Path::new());
+            Arc::make_mut(&mut self.paths).push(path);
+        } else {
             let sel = self.path.add_point(point, smooth);
             self.selection = Some(sel);
         }
@@ -33,14 +53,14 @@ impl EditSession {
     }
 
     pub fn delete(&mut self) {
-        if let Some(selected) = self.selection.take() {
-            self.selection = self.path.delete(selected);
+        if let Some(sel) = self.selection.take() {
+            self.selection = self.path_containing_pt_mut(sel).delete(sel);
         }
     }
 
     pub fn nudge_selection(&mut self, delta: Vec2) {
         if let Some(sel) = self.selection {
-            self.path.nudge(sel, delta)
+            self.path_containing_pt_mut(sel).nudge(sel, delta);
         }
     }
 
@@ -49,8 +69,12 @@ impl EditSession {
     }
 
     pub fn selected_point(&self) -> Option<SplinePoint> {
-        self.selection
-            .and_then(|id| self.path.points().iter().find(|pt| pt.id == id).copied())
+        self.selection.and_then(|id| {
+            self.iter_paths()
+                .flat_map(Path::points)
+                .find(|pt| pt.id == id)
+                .copied()
+        })
     }
 
     pub fn set_selection(&mut self, selection: Option<PointId>) {
@@ -58,24 +82,40 @@ impl EditSession {
     }
 
     pub fn maybe_convert_line_to_spline(&mut self, point: Point) {
-        self.path
-            .maybe_convert_line_to_spline(point, MIN_CLICK_DISTANCE);
+        let closest = self.iter_paths().enumerate().fold(None, |acc, (i, path)| {
+            let dist = path.nearest_segment_distance(point);
+            match acc {
+                Some((cur_idx, cur_dist)) if cur_dist > dist => Some((cur_idx, cur_dist)),
+                _ if dist < MIN_CLICK_DISTANCE => Some((i, dist)),
+                _ => None,
+            }
+        });
+        match closest {
+            Some((0, _)) => self
+                .path
+                .maybe_convert_line_to_spline(point, MIN_CLICK_DISTANCE),
+            Some((n, _)) => Arc::make_mut(&mut self.paths)
+                .get_mut(n - 1)
+                .unwrap()
+                .maybe_convert_line_to_spline(point, MIN_CLICK_DISTANCE),
+            _ => (),
+        }
     }
 
     pub fn toggle_selected_point_type(&mut self) {
         if let Some(id) = self.selection {
-            self.path.toggle_point_type(id);
+            self.path_containing_pt_mut(id).toggle_point_type(id);
         }
     }
 
     pub fn move_point(&mut self, id: PointId, pos: Point) {
-        self.path.move_point(id, pos);
+        self.path_containing_pt_mut(id).move_point(id, pos);
     }
 
     pub fn hit_test_points(&self, point: Point, max_dist: Option<f64>) -> Option<PointId> {
         let max_dist = max_dist.unwrap_or(MIN_CLICK_DISTANCE);
         let mut best = None;
-        for p in self.path.points() {
+        for p in self.iter_paths().flat_map(Path::points) {
             let dist = p.point.distance(point);
             // penalize the currently selected point
             let sel_penalty = if Some(p.id) == self.selection {
@@ -94,5 +134,14 @@ impl EditSession {
     pub fn to_json(&self) -> String {
         let paths = [self.path.solver()];
         serde_json::to_string_pretty(&paths).unwrap_or_default()
+    }
+
+    fn path_containing_pt_mut(&mut self, point: PointId) -> &mut Path {
+        if self.path.contains_point(point) {
+            &mut self.path
+        } else {
+            let paths = Arc::make_mut(&mut self.paths);
+            paths.iter_mut().find(|p| p.contains_point(point)).unwrap()
+        }
     }
 }

--- a/splinetoy/src/edit_session.rs
+++ b/splinetoy/src/edit_session.rs
@@ -40,6 +40,12 @@ impl EditSession {
     }
 
     pub fn add_point(&mut self, point: Point, smooth: bool) {
+        // if the current path is closed we need to add a new path
+        if self.path.is_closed() {
+            let path = std::mem::replace(&mut self.path, Path::new());
+            Arc::make_mut(&mut self.paths).push(path);
+        }
+
         if self
             .path
             .points()
@@ -48,8 +54,6 @@ impl EditSession {
             .unwrap_or(false)
         {
             self.path.close(smooth);
-            let path = std::mem::replace(&mut self.path, Path::new());
-            Arc::make_mut(&mut self.paths).push(path);
         } else if let Some((idx, _)) = self.nearest_segment_for_point(point) {
             let sel = match idx {
                 0 => self.path.insert_point_on_path(point),

--- a/splinetoy/src/edit_session.rs
+++ b/splinetoy/src/edit_session.rs
@@ -1,0 +1,95 @@
+//use std::collections::HashSet;
+
+use druid::{Data, Point};
+
+use crate::path::{Path, PointId, SplinePoint};
+
+const MIN_CLICK_DISTANCE: f64 = 10.0;
+const CLICK_PENALTY: f64 = MIN_CLICK_DISTANCE / 2.0;
+
+#[derive(Clone, Debug, Data)]
+pub struct EditSession {
+    pub path: Path,
+    selection: Option<PointId>,
+}
+
+impl EditSession {
+    pub fn new() -> EditSession {
+        EditSession {
+            path: Path::new(),
+            selection: None,
+        }
+    }
+
+    pub fn add_point(&mut self, point: Point, smooth: bool) {
+        if !self.path.closed() {
+            let sel = self.path.add_point(point, smooth);
+            self.selection = Some(sel);
+        }
+    }
+
+    pub fn update_for_drag(&mut self, handle: Point) {
+        self.path.update_for_drag(handle)
+    }
+
+    pub fn remove_last_segment(&mut self) {
+        self.selection = self.path.remove_last_segment()
+    }
+
+    pub fn close(&mut self) {
+        self.path.close();
+        self.selection = None;
+    }
+
+    pub fn is_selected(&self, id: PointId) -> bool {
+        Some(id) == self.selection
+    }
+
+    pub fn selected_point(&self) -> Option<SplinePoint> {
+        self.selection
+            .and_then(|id| self.path.points().iter().find(|pt| pt.id == id).copied())
+    }
+
+    pub fn set_selection(&mut self, selection: Option<PointId>) {
+        self.selection = selection;
+    }
+
+    pub fn maybe_convert_line_to_spline(&mut self, point: Point) {
+        self.path
+            .maybe_convert_line_to_spline(point, MIN_CLICK_DISTANCE);
+    }
+
+    pub fn toggle_selected_point_type(&mut self) {
+        if let Some(id) = self.selection {
+            self.path.toggle_point_type(id);
+        }
+    }
+
+    pub fn move_point(&mut self, id: PointId, pos: Point) {
+        self.path.move_point(id, pos);
+    }
+
+    pub fn hit_test_points(&self, point: Point, max_dist: Option<f64>) -> Option<PointId> {
+        let max_dist = max_dist.unwrap_or(MIN_CLICK_DISTANCE);
+        let mut best = None;
+        for p in self.path.points() {
+            let dist = p.point.distance(point);
+            // penalize the currently selected point
+            let sel_penalty = if Some(p.id) == self.selection {
+                CLICK_PENALTY
+            } else {
+                0.0
+            };
+            let score = dist + sel_penalty;
+            if dist < max_dist && best.map(|(s, _id)| score < s).unwrap_or(true) {
+                best = Some((score, p.id))
+            }
+        }
+        best.map(|(_score, id)| id)
+    }
+
+    pub fn to_json(&self) -> String {
+        let paths = [self.path.solver()];
+        serde_json::to_string_pretty(&paths).unwrap_or_default()
+    }
+}

--- a/splinetoy/src/edit_session.rs
+++ b/splinetoy/src/edit_session.rs
@@ -56,6 +56,9 @@ impl EditSession {
         if let Some(sel) = self.selection.take() {
             self.selection = self.path_containing_pt_mut(sel).delete(sel);
         }
+        if self.selection.is_none() {
+            Arc::make_mut(&mut self.paths).retain(|path| !path.points().is_empty())
+        }
     }
 
     pub fn nudge_selection(&mut self, delta: Vec2) {

--- a/splinetoy/src/edit_session.rs
+++ b/splinetoy/src/edit_session.rs
@@ -1,6 +1,6 @@
 //use std::collections::HashSet;
 
-use druid::{Data, Point};
+use druid::{Data, Point, Vec2};
 
 use crate::path::{Path, PointId, SplinePoint};
 
@@ -38,10 +38,11 @@ impl EditSession {
         }
     }
 
-    //pub fn close(&mut self) {
-    //self.path.close();
-    //self.selection = None;
-    //}
+    pub fn nudge_selection(&mut self, delta: Vec2) {
+        if let Some(sel) = self.selection {
+            self.path.nudge(sel, delta)
+        }
+    }
 
     pub fn is_selected(&self, id: PointId) -> bool {
         Some(id) == self.selection

--- a/splinetoy/src/editor.rs
+++ b/splinetoy/src/editor.rs
@@ -1,0 +1,232 @@
+use druid::{
+    commands,
+    kurbo::{Circle, Line, Point},
+    piet::StrokeStyle,
+    widget::{prelude::*, Label},
+    Color, Data, Env, HotKey, KbKey, Rect, Widget, WidgetPod,
+};
+
+use crate::edit_session::EditSession;
+use crate::mouse::{Mouse, TaggedEvent};
+use crate::path::SplinePoint;
+use crate::pen::Pen;
+use crate::toolbar::{FloatingPanel, Toolbar};
+use crate::tools::{Tool, ToolId};
+
+const ON_CURVE_CORNER_COLOR: Color = Color::rgb8(0x4B, 0x4E, 0xFF);
+const ON_CURVE_SMOOTH_COLOR: Color = Color::rgb8(0x37, 0xA7, 0x62);
+const OFF_CURVE_COLOR: Color = Color::grey8(0xbb);
+const OFF_CURVE_SELECTED_COLOR: Color = Color::grey8(0x88);
+const FLOATING_PANEL_PADDING: f64 = 20.0;
+
+pub struct Editor {
+    toolbar: WidgetPod<(), FloatingPanel<Toolbar>>,
+    points_label: Label<()>,
+    mouse: Mouse,
+    tool: Box<dyn Tool>,
+    label_size: Size,
+}
+
+impl Editor {
+    pub fn new() -> Editor {
+        Editor {
+            points_label: Label::new("")
+                .with_text_size(12.0)
+                .with_text_color(Color::grey(0.3)),
+            toolbar: WidgetPod::new(FloatingPanel::new(Toolbar::default())),
+            label_size: Size::ZERO,
+            mouse: Mouse::default(),
+            tool: Box::new(Pen::default()),
+        }
+    }
+
+    fn set_tool(&mut self, ctx: &mut EventCtx, tool: ToolId) {
+        if tool != self.tool.name() {
+            let tool = crate::tools::tool_for_id(tool).unwrap();
+            self.tool = tool;
+            self.mouse.reset();
+            self.tool.init_mouse(&mut self.mouse);
+            let cursor = self.tool.preferred_cursor();
+            ctx.set_cursor(&cursor);
+        }
+    }
+
+    fn send_mouse(&mut self, ctx: &mut EventCtx, event: TaggedEvent, data: &mut EditSession) {
+        if !event.inner().button.is_right() {
+            // set active, to ensure we receive events if the mouse leaves
+            // the window:
+            match &event {
+                TaggedEvent::Down(_) => ctx.set_active(true),
+                TaggedEvent::Up(m) if m.buttons.is_empty() => ctx.set_active(false),
+                _ => (),
+            };
+
+            self.tool.mouse_event(event, &mut self.mouse, ctx, data);
+        }
+    }
+}
+
+impl Widget<EditSession> for Editor {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut EditSession, env: &Env) {
+        if let Event::KeyDown(k) = event {
+            if let Some(new_tool) = self.toolbar.widget().inner().tool_for_keypress(k) {
+                let cmd = crate::toolbar::SET_TOOL.with(new_tool);
+                ctx.submit_command(cmd);
+                ctx.set_handled();
+                return;
+            }
+        }
+
+        self.toolbar.event(ctx, event, &mut (), env);
+        match event {
+            Event::WindowConnected => {
+                ctx.set_cursor(&self.tool.preferred_cursor());
+                ctx.submit_command(crate::toolbar::SET_TOOL.with(crate::pen::TOOL_NAME));
+                ctx.request_update();
+                ctx.request_focus();
+            }
+            Event::Command(cmd) if cmd.is(crate::toolbar::SET_TOOL) => {
+                let tool = cmd.get_unchecked(crate::toolbar::SET_TOOL);
+                self.set_tool(ctx, tool);
+            }
+            Event::MouseUp(m) => self.send_mouse(ctx, TaggedEvent::Up(m.clone()), data),
+            Event::MouseMove(m) => self.send_mouse(ctx, TaggedEvent::Moved(m.clone()), data),
+            Event::MouseDown(m) => self.send_mouse(ctx, TaggedEvent::Down(m.clone()), data),
+            Event::KeyDown(key) if key.key == KbKey::Backspace => {
+                data.remove_last_segment();
+            }
+            Event::KeyDown(key) if key.key == KbKey::Escape => {
+                data.close();
+            }
+            Event::Command(cmd) if cmd.is(commands::SAVE_FILE) => {
+                if let Some(file_info) = cmd.get_unchecked(commands::SAVE_FILE) {
+                    let json = data.to_json();
+                    if let Err(e) = std::fs::write(file_info.path(), json.as_bytes()) {
+                        println!("Error writing json: {}", e);
+                    }
+                }
+            }
+            _ => (),
+        }
+        self.points_label.event(ctx, event, &mut (), env);
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _: &EditSession, env: &Env) {
+        self.points_label.lifecycle(ctx, event, &(), env);
+        self.toolbar.lifecycle(ctx, event, &(), env);
+    }
+
+    fn update(
+        &mut self,
+        ctx: &mut UpdateCtx,
+        old_data: &EditSession,
+        data: &EditSession,
+        env: &Env,
+    ) {
+        if !old_data.same(data) {
+            ctx.request_layout();
+        }
+        self.points_label.update(ctx, &(), &(), env);
+        self.toolbar.update(ctx, &(), env);
+    }
+
+    fn layout(
+        &mut self,
+        ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        _: &EditSession,
+        env: &Env,
+    ) -> Size {
+        let child_bc = bc.loosen();
+        let size = self.toolbar.layout(ctx, &child_bc, &(), env);
+        let orig = (FLOATING_PANEL_PADDING, FLOATING_PANEL_PADDING);
+        self.toolbar
+            .set_layout_rect(ctx, &(), env, Rect::from_origin_size(orig, size));
+        self.label_size = self.points_label.layout(ctx, &bc.loosen(), &(), env);
+        bc.max()
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &EditSession, env: &Env) {
+        ctx.clear(Color::WHITE);
+        ctx.stroke(data.path.bezier(), &Color::BLACK, 1.0);
+        if !data.path.points().is_empty() {
+            let mut last_point = data.path.points()[0];
+            for pt in data.path.points() {
+                let is_selected = data.is_selected(pt.id);
+                if pt.is_on_curve() {
+                    draw_on_curve(ctx, pt.point, pt.is_smooth(), is_selected);
+                }
+                let is_selected = handle_is_selected(*pt, last_point, data);
+                draw_handle_if_needed(ctx, *pt, last_point, is_selected);
+                last_point = *pt;
+            }
+
+            if let Some(pt) = data.path.trailing() {
+                draw_handle_if_needed(ctx, SplinePoint::control(pt, false), last_point, false);
+            }
+        }
+
+        let origin = (10.0, ctx.size().height - self.label_size.height - 10.0);
+        self.points_label.draw_at(ctx, origin);
+        self.toolbar.paint(ctx, &(), env);
+    }
+}
+
+fn handle_is_selected(p1: SplinePoint, p2: SplinePoint, data: &EditSession) -> bool {
+    (p1.is_control() && data.is_selected(p1.id)) || (p2.is_control() && data.is_selected(p2.id))
+}
+
+fn draw_on_curve(ctx: &mut PaintCtx, pt: Point, smooth: bool, selected: bool) {
+    let rad = if selected { 5.0 } else { 4.0 };
+    if smooth {
+        let circ = Circle::new(pt, rad);
+        if selected {
+            ctx.fill(circ, &ON_CURVE_SMOOTH_COLOR);
+        } else {
+            ctx.stroke(circ, &ON_CURVE_SMOOTH_COLOR, 1.0);
+        }
+    } else {
+        let square = Rect::from_center_size(pt, (rad * 2.0, rad * 2.0));
+        if selected {
+            ctx.fill(square, &ON_CURVE_CORNER_COLOR);
+        } else {
+            ctx.stroke(square, &ON_CURVE_CORNER_COLOR, 1.0);
+        }
+    }
+}
+
+fn draw_handle_if_needed(ctx: &mut PaintCtx, p1: SplinePoint, p2: SplinePoint, selected: bool) {
+    if p1.type_.variant_eq(&p2.type_) {
+        return;
+    }
+
+    let is_auto = p1.is_auto() || p2.is_auto();
+    let handle_pt = if p1.is_control() { p1.point } else { p2.point };
+    let thickness = if selected { 2.0 } else { 1.0 };
+    let radius = if selected { 4.0 } else { 3.0 };
+    let edge = radius * 2.0;
+    let line = Line::new(p1.point, p2.point);
+    let handle_color = if selected {
+        &OFF_CURVE_SELECTED_COLOR
+    } else {
+        &OFF_CURVE_COLOR
+    };
+
+    if is_auto {
+        let stroke = StrokeStyle::new().dash(vec![2.0, 4.0], 1.0);
+        ctx.stroke_styled(line, &OFF_CURVE_COLOR, 1.0, &stroke);
+        let rect = Rect::from_center_size(handle_pt, (edge, edge));
+        let line1 = Line::new(rect.origin(), (rect.max_x(), rect.max_y()));
+        let line2 = Line::new((rect.x0, rect.y1), (rect.x1, rect.y0));
+        ctx.stroke(line1, handle_color, thickness);
+        ctx.stroke(line2, handle_color, thickness);
+    } else {
+        ctx.stroke(line, &OFF_CURVE_COLOR, 1.0);
+        let circ = Circle::new(handle_pt, radius);
+        if selected {
+            ctx.fill(circ, handle_color);
+        } else {
+            ctx.stroke(circ, handle_color, 1.0);
+        }
+    }
+}

--- a/splinetoy/src/editor.rs
+++ b/splinetoy/src/editor.rs
@@ -151,21 +151,24 @@ impl Widget<EditSession> for Editor {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &EditSession, env: &Env) {
         ctx.clear(Color::WHITE);
-        ctx.stroke(data.path.bezier(), &Color::BLACK, 1.0);
-        if !data.path.points().is_empty() {
-            let mut last_point = data.path.points()[0];
-            for pt in data.path.points() {
-                let is_selected = data.is_selected(pt.id);
-                if pt.is_on_curve() {
-                    draw_on_curve(ctx, pt.point, pt.is_smooth(), is_selected);
-                }
-                let is_selected = handle_is_selected(*pt, last_point, data);
-                draw_handle_if_needed(ctx, *pt, last_point, is_selected);
-                last_point = *pt;
-            }
 
-            if let Some(pt) = data.path.trailing() {
-                draw_handle_if_needed(ctx, SplinePoint::control(pt, true), last_point, false);
+        for path in data.iter_paths() {
+            ctx.stroke(path.bezier(), &Color::BLACK, 1.0);
+            if !path.points().is_empty() {
+                let mut last_point = path.points()[0];
+                for pt in path.points() {
+                    let is_selected = data.is_selected(pt.id);
+                    if pt.is_on_curve() {
+                        draw_on_curve(ctx, pt.point, pt.is_smooth(), is_selected);
+                    }
+                    let is_selected = handle_is_selected(*pt, last_point, data);
+                    draw_handle_if_needed(ctx, *pt, last_point, is_selected);
+                    last_point = *pt;
+                }
+
+                if let Some(pt) = path.trailing() {
+                    draw_handle_if_needed(ctx, SplinePoint::control(pt, true), last_point, false);
+                }
             }
         }
 

--- a/splinetoy/src/editor.rs
+++ b/splinetoy/src/editor.rs
@@ -3,7 +3,7 @@ use druid::{
     kurbo::{Circle, Line, Point},
     piet::StrokeStyle,
     widget::{prelude::*, Label},
-    Color, Data, Env, KbKey, Rect, Widget, WidgetPod,
+    Color, Data, Env, Rect, Widget, WidgetPod,
 };
 
 use crate::edit_session::EditSession;
@@ -95,11 +95,11 @@ impl Widget<EditSession> for Editor {
             Event::MouseUp(m) => self.send_mouse(ctx, TaggedEvent::Up(m.clone()), data),
             Event::MouseMove(m) => self.send_mouse(ctx, TaggedEvent::Moved(m.clone()), data),
             Event::MouseDown(m) => self.send_mouse(ctx, TaggedEvent::Down(m.clone()), data),
-            Event::KeyDown(key) if key.key == KbKey::Backspace => {
-                data.remove_last_segment();
+            Event::KeyDown(k) => {
+                self.tool.key_down(k, ctx, data);
             }
-            Event::KeyDown(key) if key.key == KbKey::Escape => {
-                data.close();
+            Event::KeyUp(k) => {
+                self.tool.key_up(k, ctx, data);
             }
             Event::Command(cmd) if cmd.is(commands::SAVE_FILE) => {
                 if let Some(file_info) = cmd.get_unchecked(commands::SAVE_FILE) {

--- a/splinetoy/src/editor.rs
+++ b/splinetoy/src/editor.rs
@@ -155,17 +155,17 @@ impl Widget<EditSession> for Editor {
         for path in data.iter_paths() {
             ctx.stroke(path.bezier(), &Color::BLACK, 1.0);
             if !path.points().is_empty() {
-                let first_selected = data.is_selected(path.points()[0].id);
+                let first_selected = data.is_selected(path.first_point().unwrap().id);
                 draw_first_point(ctx, path, first_selected);
-                let mut last_point = path.points()[0];
-                for pt in path.points().iter().skip(1) {
+                let mut last_point = path.first_point().unwrap();
+                for pt in path.iter_points().skip(1) {
                     let is_selected = data.is_selected(pt.id);
                     if pt.is_on_curve() {
                         draw_on_curve(ctx, pt.point, pt.is_smooth(), is_selected);
                     }
-                    let is_selected = handle_is_selected(*pt, last_point, data);
-                    draw_handle_if_needed(ctx, *pt, last_point, is_selected);
-                    last_point = *pt;
+                    let is_selected = handle_is_selected(pt, last_point, data);
+                    draw_handle_if_needed(ctx, pt, last_point, is_selected);
+                    last_point = pt;
                 }
 
                 if let Some(pt) = path.trailing() {

--- a/splinetoy/src/editor.rs
+++ b/splinetoy/src/editor.rs
@@ -2,7 +2,7 @@ use druid::{
     commands,
     kurbo::{Circle, CubicBez, Line, PathSeg, Point, Vec2},
     piet::StrokeStyle,
-    widget::{prelude::*, Label},
+    widget::prelude::*,
     Color, Data, Env, KbKey, Rect, Widget, WidgetPod,
 };
 
@@ -21,24 +21,18 @@ const FLOATING_PANEL_PADDING: f64 = 20.0;
 
 pub struct Editor {
     toolbar: WidgetPod<(), FloatingPanel<Toolbar>>,
-    points_label: Label<()>,
     mouse: Mouse,
-    preview: bool,
     tool: Box<dyn Tool>,
-    label_size: Size,
+    preview: bool,
 }
 
 impl Editor {
     pub fn new() -> Editor {
         Editor {
-            points_label: Label::new("")
-                .with_text_size(12.0)
-                .with_text_color(Color::grey(0.3)),
             toolbar: WidgetPod::new(FloatingPanel::new(Toolbar::default())),
-            label_size: Size::ZERO,
             mouse: Mouse::default(),
-            preview: false,
             tool: Box::new(Pen::default()),
+            preview: false,
         }
     }
 
@@ -121,11 +115,9 @@ impl Widget<EditSession> for Editor {
             }
             _ => (),
         }
-        self.points_label.event(ctx, event, &mut (), env);
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _: &EditSession, env: &Env) {
-        self.points_label.lifecycle(ctx, event, &(), env);
         self.toolbar.lifecycle(ctx, event, &(), env);
     }
 
@@ -139,7 +131,6 @@ impl Widget<EditSession> for Editor {
         if !old_data.same(data) {
             ctx.request_layout();
         }
-        self.points_label.update(ctx, &(), &(), env);
         self.toolbar.update(ctx, &(), env);
     }
 
@@ -155,7 +146,6 @@ impl Widget<EditSession> for Editor {
         let orig = (FLOATING_PANEL_PADDING, FLOATING_PANEL_PADDING);
         self.toolbar
             .set_layout_rect(ctx, &(), env, Rect::from_origin_size(orig, size));
-        self.label_size = self.points_label.layout(ctx, &bc.loosen(), &(), env);
         bc.max()
     }
 
@@ -188,8 +178,6 @@ impl Widget<EditSession> for Editor {
             }
         }
 
-        let origin = (10.0, ctx.size().height - self.label_size.height - 10.0);
-        self.points_label.draw_at(ctx, origin);
         self.toolbar.paint(ctx, &(), env);
     }
 }

--- a/splinetoy/src/editor.rs
+++ b/splinetoy/src/editor.rs
@@ -3,7 +3,7 @@ use druid::{
     kurbo::{Circle, Line, Point},
     piet::StrokeStyle,
     widget::{prelude::*, Label},
-    Color, Data, Env, HotKey, KbKey, Rect, Widget, WidgetPod,
+    Color, Data, Env, KbKey, Rect, Widget, WidgetPod,
 };
 
 use crate::edit_session::EditSession;
@@ -78,6 +78,9 @@ impl Widget<EditSession> for Editor {
         }
 
         self.toolbar.event(ctx, event, &mut (), env);
+        if ctx.is_handled() {
+            return;
+        }
         match event {
             Event::WindowConnected => {
                 ctx.set_cursor(&self.tool.preferred_cursor());
@@ -162,7 +165,7 @@ impl Widget<EditSession> for Editor {
             }
 
             if let Some(pt) = data.path.trailing() {
-                draw_handle_if_needed(ctx, SplinePoint::control(pt, false), last_point, false);
+                draw_handle_if_needed(ctx, SplinePoint::control(pt, true), last_point, false);
             }
         }
 

--- a/splinetoy/src/main.rs
+++ b/splinetoy/src/main.rs
@@ -1,0 +1,66 @@
+mod edit_session;
+mod editor;
+mod mouse;
+mod path;
+mod pen;
+mod select;
+mod toolbar;
+mod tools;
+
+use druid::{
+    commands, platform_menus, AppLauncher, FileDialogOptions, FileSpec, LocalizedString, MenuDesc,
+    MenuItem, SysMods, WindowDesc,
+};
+
+use edit_session::EditSession;
+use editor::Editor;
+
+pub fn main() {
+    // describe the main window
+    let main_window = WindowDesc::new(|| Editor::new())
+        .title("Spline Toy")
+        .menu(make_menu())
+        .with_min_size((200., 200.))
+        .window_size((600.0, 800.0));
+
+    // create the initial app state
+    let initial_state = EditSession::new();
+
+    // start the application
+    AppLauncher::with_window(main_window)
+        .launch(initial_state)
+        .expect("Failed to launch application");
+}
+
+fn file_menu() -> MenuDesc<EditSession> {
+    pub const JSON_TYPE: FileSpec = FileSpec::new("JSON Data", &["json"]);
+
+    MenuDesc::new(LocalizedString::new("common-menu-file-menu"))
+        .append(platform_menus::mac::file::new_file().disabled())
+        .append(platform_menus::mac::file::new_file().disabled())
+        .append_separator()
+        .append(platform_menus::mac::file::close())
+        .append(
+            MenuItem::new(
+                LocalizedString::new("save-as-json").with_placeholder("Save JSON..."),
+                commands::SHOW_SAVE_PANEL
+                    .with(FileDialogOptions::new().allowed_types(vec![JSON_TYPE])),
+            )
+            .hotkey(SysMods::Cmd, "s"),
+        )
+        .append_separator()
+        .append(platform_menus::mac::file::page_setup().disabled())
+        .append(platform_menus::mac::file::print().disabled())
+}
+
+/// The main window/app menu.
+#[allow(unused_mut)]
+fn make_menu() -> MenuDesc<EditSession> {
+    let mut menu = MenuDesc::empty();
+    #[cfg(target_os = "macos")]
+    {
+        menu = menu.append(platform_menus::mac::application::default());
+    }
+
+    menu.append(file_menu())
+}

--- a/splinetoy/src/mouse.rs
+++ b/splinetoy/src/mouse.rs
@@ -1,0 +1,393 @@
+// Copied from Runebender
+
+//! Easier handling of mouse events.
+//!
+//! Handling the various permutations and combinations of mouse events is messy,
+//! repetitive, and error prone.
+//!
+//! This module implements a state machine that handles the raw event processing,
+//! identifying important events and transitions.
+//!
+//! # Use
+//!
+//! The state machine itself is exposed via the [`Mouse`] struct. You are
+//! responsible for instantiating this struct, and it is expected to persist
+//! between mouse events.
+//!
+//! To react to state changes, you must implement the [`MouseDelegate`] trait;
+//! you only need to implement the methods you are interested in.
+//!
+//! When a mouse event arrives, you pass the event along with your delegate to
+//! the [`Mouse`] struct; if that event causes a state change, the corresponding
+//! method on your delegate will be called.
+//!
+//! # Example
+//! ```
+//! use runebender::mouse::{Mouse, MouseDelegate};
+//! use druid::shell::window::{MouseEvent, MouseButton, KeyModifiers};
+//! use druid::kurbo::Point;
+//!
+//! struct SimpleDelegate(usize);
+//!
+//! impl MouseDelegate<()> for SimpleDelegate {
+//!     fn left_click(&mut self, _event: &MouseEvent, _data: &mut T) -> bool {
+//!         self.0 += 1;
+//!     }
+//! }
+//!
+//! let event = MouseEvent {
+//!     pos: Point::new(20., 20.,),
+//!     mods: KeyModifiers::None,
+//!     count: 1,
+//!     button: MouseButton::Left,
+//! };
+//!
+//! let mut mouse = Mouse::default();
+//! let mut delegate = SimpleDelegate(0);
+//! mouse.mouse_down(event.clone(), &mut (), &mut delegate);
+//! assert_eq!(delegate.0, 0);
+//! mouse.mouse_up(event.clone(), &mut (), &mut delegate);
+//! assert_eq!(delegate.0, 1);
+//! ```
+
+use druid::kurbo::Point;
+use druid::{EventCtx, Modifiers, MouseButton, MouseButtons, MouseEvent};
+use std::mem;
+
+const DEFAULT_MIN_DRAG_DISTANCE: f64 = 2.0;
+
+/// Handles raw mouse events, parsing them into gestures that it forwards
+/// to a delegate.
+#[derive(Debug, Clone)]
+pub struct Mouse {
+    state: MouseState,
+    /// The distance the mouse must travel with a button down for it to
+    /// be considered a drag gesture.
+    pub min_drag_distance: f64,
+}
+
+/// A convenience type for passing around mouse events while keeping track
+/// of the event type.
+#[derive(Debug, Clone)]
+pub enum TaggedEvent {
+    Down(MouseEvent),
+    Up(MouseEvent),
+    Moved(MouseEvent),
+}
+
+#[derive(Debug, Clone)]
+enum MouseState {
+    /// No mouse buttons are active.
+    Up(MouseEvent),
+    /// A mouse button has been pressed.
+    Down(MouseEvent),
+    /// The mouse has been moved some threshold distance with a button pressed.
+    Drag {
+        start: MouseEvent,
+        current: MouseEvent,
+    },
+    /// A state only used as a placeholder during event handling.
+    #[doc(hidden)]
+    Transition,
+}
+
+/// The state of an in-progress drag gesture.
+#[derive(Debug, Clone, Copy)]
+#[allow(unused)]
+pub struct Drag<'a> {
+    /// The event that started this drag
+    pub start: &'a MouseEvent,
+    /// The previous event in this drag
+    pub prev: &'a MouseEvent,
+    /// The current event in this drag
+    pub current: &'a MouseEvent,
+}
+
+/// A trait for types that want fine grained information about mouse events.
+pub trait MouseDelegate<T> {
+    /// Called on any mouse movement.
+    #[allow(unused)]
+    fn mouse_moved(&mut self, _event: &MouseEvent, _data: &mut T) {}
+
+    /// Called when the left mouse button is pressed.
+    #[allow(unused)]
+    fn left_down(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    /// Called when the left mouse button is released.
+    #[allow(unused)]
+    fn left_up(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    /// Called when the left mouse button is released, if there has not already
+    /// been a drag event.
+    #[allow(unused)]
+    fn left_click(&mut self, _event: &MouseEvent, _data: &mut T) {}
+
+    /// Called when the mouse moves a minimum distance with the left mouse
+    /// button pressed.
+    #[allow(unused)]
+    fn left_drag_began(&mut self, _drag: Drag, _data: &mut T) {}
+    /// Called when the mouse moves after a drag gesture has been recognized.
+    #[allow(unused)]
+    fn left_drag_changed(&mut self, _drag: Drag, _data: &mut T) {}
+    /// Called when the left mouse button is released, after a drag gesture
+    /// has been recognized.
+    #[allow(unused)]
+    fn left_drag_ended(&mut self, _drag: Drag, _data: &mut T) {}
+
+    /// Called when the right mouse button is pressed.
+    #[allow(unused)]
+    fn right_down(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    /// Called when the right mouse button is released.
+    #[allow(unused)]
+    fn right_up(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    /// Called when the right mouse button is released, if there has not already
+    /// been a drag event.
+    #[allow(unused)]
+    fn right_click(&mut self, _event: &MouseEvent, _data: &mut T) {}
+
+    /// Called when the mouse moves a minimum distance with the right mouse
+    /// button pressed.
+    #[allow(unused)]
+    fn right_drag_began(&mut self, _drag: Drag, _data: &mut T) {}
+    /// Called when the mouse moves after a drag gesture has been recognized.
+    #[allow(unused)]
+    fn right_drag_changed(&mut self, _drag: Drag, _data: &mut T) {}
+    /// Called when the right mouse button is released, after a drag gesture
+    /// has been recognized.
+    #[allow(unused)]
+    fn right_drag_ended(&mut self, _drag: Drag, _data: &mut T) {}
+
+    #[allow(unused)]
+    fn other_down(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    #[allow(unused)]
+    fn other_up(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    #[allow(unused)]
+    fn other_click(&mut self, _event: &MouseEvent, _data: &mut T) {}
+
+    #[allow(unused)]
+    fn other_drag_began(&mut self, _drag: Drag, _data: &mut T) {}
+    #[allow(unused)]
+    fn other_drag_changed(&mut self, _drag: Drag, _data: &mut T) {}
+    #[allow(unused)]
+    fn other_drag_ended(&mut self, _drag: Drag, _data: &mut T) {}
+
+    #[allow(unused)]
+    fn cancel(&mut self, data: &mut T);
+}
+
+impl std::default::Default for Mouse {
+    fn default() -> Mouse {
+        Mouse {
+            min_drag_distance: DEFAULT_MIN_DRAG_DISTANCE,
+            state: MouseState::Up(MouseEvent {
+                pos: Point::ZERO,
+                window_pos: Point::ZERO,
+                mods: Modifiers::default(),
+                count: 0,
+                button: MouseButton::None,
+                buttons: MouseButtons::default(),
+                focus: false,
+                wheel_delta: Default::default(),
+            }),
+        }
+    }
+}
+
+impl TaggedEvent {
+    pub fn inner(&self) -> &MouseEvent {
+        match self {
+            TaggedEvent::Down(m) => m,
+            TaggedEvent::Up(m) => m,
+            TaggedEvent::Moved(m) => m,
+        }
+    }
+}
+
+impl Mouse {
+    /// reset any settable internal state to its default value.
+    pub fn reset(&mut self) {
+        self.min_drag_distance = DEFAULT_MIN_DRAG_DISTANCE;
+    }
+
+    /// The current position of  the mouse.
+    #[allow(dead_code)]
+    pub fn pos(&self) -> Point {
+        match &self.state {
+            MouseState::Up(e) => e.pos,
+            MouseState::Down(e) => e.pos,
+            MouseState::Drag { current, .. } => current.pos,
+            _ => panic!("transition is not an actual state :/"),
+        }
+    }
+
+    pub fn mouse_event<T>(
+        &mut self,
+        event: TaggedEvent,
+        data: &mut T,
+        delegate: &mut dyn MouseDelegate<T>,
+    ) {
+        match event {
+            TaggedEvent::Up(event) => self.mouse_up(event, data, delegate),
+            TaggedEvent::Down(event) => self.mouse_down(event, data, delegate),
+            TaggedEvent::Moved(event) => self.mouse_moved(event, data, delegate),
+        }
+    }
+
+    pub fn mouse_moved<T>(
+        &mut self,
+        event: MouseEvent,
+        data: &mut T,
+        delegate: &mut dyn MouseDelegate<T>,
+    ) {
+        let prev_state = mem::replace(&mut self.state, MouseState::Transition);
+        self.state = match prev_state {
+            MouseState::Up(_) => {
+                delegate.mouse_moved(&event, data);
+                MouseState::Up(event)
+            }
+            MouseState::Down(prev) => {
+                if prev.pos.distance(event.pos) > self.min_drag_distance {
+                    let drag = Drag::new(&prev, &prev, &event);
+                    if prev.button.is_left() {
+                        delegate.left_drag_began(drag, data)
+                    } else if prev.button.is_right() {
+                        delegate.right_drag_began(drag, data)
+                    } else {
+                        delegate.other_drag_began(drag, data)
+                    };
+                    MouseState::Drag {
+                        start: prev,
+                        current: event,
+                    }
+                } else {
+                    MouseState::Down(prev)
+                }
+            }
+            MouseState::Drag { start, current } => {
+                let drag = Drag::new(&start, &current, &event);
+                if start.button.is_left() {
+                    delegate.left_drag_changed(drag, data)
+                } else if start.button.is_right() {
+                    delegate.right_drag_changed(drag, data)
+                } else {
+                    delegate.other_drag_changed(drag, data)
+                };
+                MouseState::Drag {
+                    start,
+                    current: event,
+                }
+            }
+            MouseState::Transition => panic!("ahhhhhhh"),
+        };
+    }
+
+    pub fn mouse_down<T>(
+        &mut self,
+        event: MouseEvent,
+        data: &mut T,
+        delegate: &mut dyn MouseDelegate<T>,
+    ) {
+        let prev_state = mem::replace(&mut self.state, MouseState::Transition);
+        self.state = match prev_state {
+            MouseState::Up(_) => {
+                if event.button.is_left() {
+                    delegate.left_down(&event, data)
+                } else if event.button.is_right() {
+                    delegate.right_down(&event, data)
+                } else {
+                    delegate.other_down(&event, data)
+                };
+                MouseState::Down(event)
+            }
+            MouseState::Down(prev) => {
+                assert!(prev.button != event.button);
+                // if a second button is pressed while we're handling an event
+                // we just ignore it. At some point we could consider an event for this.
+                MouseState::Down(prev)
+            }
+            MouseState::Drag { start, .. } => {
+                if start.button != event.button {
+                    //log::warn!("mouse click while drag in progress; not correctly receiving mouse up events?");
+                }
+                MouseState::Drag {
+                    start,
+                    current: event,
+                }
+            }
+            MouseState::Transition => panic!("ahhhhhhh"),
+        };
+    }
+
+    pub fn mouse_up<T>(
+        &mut self,
+        event: MouseEvent,
+        data: &mut T,
+        delegate: &mut dyn MouseDelegate<T>,
+    ) {
+        let prev_state = mem::replace(&mut self.state, MouseState::Transition);
+        self.state = match prev_state {
+            MouseState::Up(_) => MouseState::Up(event),
+            MouseState::Down(prev) => {
+                if event.button == prev.button {
+                    if prev.button.is_left() {
+                        delegate.left_click(&event, data);
+                        delegate.left_up(&event, data);
+                    } else if prev.button.is_right() {
+                        delegate.right_click(&event, data);
+                        delegate.right_up(&event, data);
+                    } else {
+                        delegate.other_click(&event, data);
+                        delegate.other_up(&event, data);
+                    };
+                    MouseState::Up(event)
+                } else {
+                    MouseState::Down(prev)
+                }
+            }
+            MouseState::Drag { start, current } => {
+                if event.button == start.button {
+                    let drag = Drag {
+                        start: &start,
+                        current: &event,
+                        prev: &current,
+                    };
+                    if start.button.is_left() {
+                        delegate.left_drag_ended(drag, data);
+                        delegate.left_up(&event, data);
+                    } else if start.button.is_right() {
+                        delegate.right_drag_ended(drag, data);
+                        delegate.right_up(&event, data);
+                    } else {
+                        delegate.other_drag_ended(drag, data);
+                        delegate.other_up(&event, data);
+                    };
+                    MouseState::Up(event)
+                } else {
+                    MouseState::Drag { start, current }
+                }
+            }
+            MouseState::Transition => panic!("ahhhhhhh"),
+        };
+    }
+
+    #[allow(dead_code)]
+    fn cancel<T>(&mut self, data: &mut T, delegate: &mut dyn MouseDelegate<T>) {
+        let prev_state = mem::replace(&mut self.state, MouseState::Transition);
+        let last_event = match prev_state {
+            MouseState::Down(event) => event,
+            MouseState::Up(event) => event,
+            MouseState::Drag { current, .. } => current,
+            MouseState::Transition => panic!("ahhhhhhh"),
+        };
+        delegate.cancel(data);
+        self.state = MouseState::Up(last_event);
+    }
+}
+
+impl<'a> Drag<'a> {
+    fn new(start: &'a MouseEvent, prev: &'a MouseEvent, current: &'a MouseEvent) -> Drag<'a> {
+        Drag {
+            start,
+            prev,
+            current,
+        }
+    }
+}

--- a/splinetoy/src/mouse.rs
+++ b/splinetoy/src/mouse.rs
@@ -51,7 +51,7 @@
 //! ```
 
 use druid::kurbo::Point;
-use druid::{EventCtx, Modifiers, MouseButton, MouseButtons, MouseEvent};
+use druid::{Modifiers, MouseButton, MouseButtons, MouseEvent};
 use std::mem;
 
 const DEFAULT_MIN_DRAG_DISTANCE: f64 = 2.0;

--- a/splinetoy/src/path.rs
+++ b/splinetoy/src/path.rs
@@ -188,18 +188,13 @@ impl Path {
 
     fn spline_to(&mut self, p3: impl Into<Point>, smooth: bool) {
         let p3 = p3.into();
-        let prev = self.points().last().cloned().unwrap();
-        let (p1, auto) = match self.trailing.take() {
-            Some(pt) => (pt, false),
-            None => (p3.lerp(prev.point, 1.0 / 3.0), true),
-        };
-        let p2 = p3.lerp(prev.point, 2.0 / 3.0);
-        self.points_mut().push(SplinePoint::control(p1, auto));
+        let prev = self.points().last().cloned().unwrap().point;
+        let p1 = prev.lerp(p3, 1.0 / 3.0);
+        let p2 = prev.lerp(p3, 2.0 / 3.0);
+        self.points_mut().push(SplinePoint::control(p1, true));
         self.points_mut().push(SplinePoint::control(p2, true));
         self.points_mut().push(SplinePoint::on_curve(p3, smooth));
-        // for the solver, convert auto to Option
-        let p1 = if auto { None } else { Some(p1) };
-        self.solver.spline_to(p1, None, p3, smooth);
+        self.solver.spline_to(None, None, p3, smooth);
     }
 
     pub fn remove_last_segment(&mut self) -> Option<PointId> {
@@ -336,7 +331,7 @@ impl Path {
                 let p1 = prev_point.lerp(pt.point, 1.0 / 3.0);
                 let p2 = prev_point.lerp(pt.point, 2.0 / 3.0);
                 self.points_mut().insert(i, SplinePoint::control(p1, true));
-                self.points_mut().insert(i, SplinePoint::control(p2, true));
+                self.points_mut().insert(i + 1, SplinePoint::control(p2, true));
                 break;
             }
             segs_seen += 1;

--- a/splinetoy/src/path.rs
+++ b/splinetoy/src/path.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use druid::kurbo::{BezPath, Line, ParamCurveNearest};
-use druid::{Data, Point};
+use druid::{Data, Point, Vec2};
 use spline::{Element, SplineSpec};
 
 #[derive(Clone, Debug, Data)]
@@ -235,6 +235,12 @@ impl Path {
         self.after_change();
         // select the last point on delete?
         self.points().last().map(|pt| pt.id)
+    }
+
+    pub fn nudge(&mut self, id: PointId, delta: Vec2) {
+        let idx = self.idx_for_point(id).unwrap();
+        let new_pos = self.points().get(idx).unwrap().point + delta;
+        self.move_point(id, new_pos);
     }
 
     //pub fn close(&mut self) {

--- a/splinetoy/src/path.rs
+++ b/splinetoy/src/path.rs
@@ -253,7 +253,7 @@ impl Path {
 
         for (i, pt) in self.points().iter().skip(skip_n).enumerate() {
             if segs_seen == seg_idx {
-                pt_idx = i;
+                pt_idx = i + skip_n;
                 break;
             }
             if pt.is_on_curve() {
@@ -265,7 +265,7 @@ impl Path {
         let is_smooth = self
             .points()
             .iter()
-            .skip(skip_n + pt_idx)
+            .skip(pt_idx)
             .skip_while(|pt| pt.is_control())
             .next()
             .map(SplinePoint::is_smooth)

--- a/splinetoy/src/path.rs
+++ b/splinetoy/src/path.rs
@@ -469,7 +469,6 @@ impl Path {
 struct SplineElementIter {
     points: Arc<Vec<SplinePoint>>,
     start: Option<Point>,
-    //started: bool,
     ix: usize,
 }
 
@@ -482,15 +481,11 @@ impl SplineElementIter {
         };
         let start = start.map(|pt| pt.point);
         let ix = if closed { 0 } else { 1 };
-        SplineElementIter {
-            points,
-            start,
-            ix,
-        }
+        SplineElementIter { points, start, ix }
     }
 
     fn is_done(&self) -> bool {
-        self.ix == self.points.len()
+        self.points.is_empty() || self.ix == self.points.len()
     }
 }
 

--- a/splinetoy/src/path.rs
+++ b/splinetoy/src/path.rs
@@ -1,0 +1,507 @@
+use std::sync::Arc;
+
+use druid::kurbo::{BezPath, Line, ParamCurveNearest};
+use druid::{Data, Point};
+use spline::{Element, SplineSpec};
+
+#[derive(Clone, Debug, Data)]
+pub struct Path {
+    points: Arc<Vec<SplinePoint>>,
+    bezier: Arc<BezPath>,
+    trailing: Option<Point>,
+    #[data(ignore)]
+    solver: SplineSpec,
+    closed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Data)]
+pub struct PointId {
+    id: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Data)]
+pub enum PointType {
+    OnCurve { smooth: bool },
+    Control { auto: bool },
+}
+
+#[derive(Debug, Clone, Copy, Data)]
+pub struct SplinePoint {
+    pub type_: PointType,
+    pub point: Point,
+    pub id: PointId,
+}
+
+impl PointId {
+    fn next() -> Self {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(5);
+        PointId {
+            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+        }
+    }
+}
+
+impl PointType {
+    pub fn variant_eq(&self, other: &PointType) -> bool {
+        match (self, other) {
+            (PointType::OnCurve { .. }, PointType::OnCurve { .. }) => true,
+            (PointType::Control { .. }, PointType::Control { .. }) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_auto(&self) -> bool {
+        matches!(self, PointType::Control { auto: true })
+    }
+
+    pub fn is_control(&self) -> bool {
+        matches!(self, PointType::Control { .. })
+    }
+
+    pub fn is_on_curve(&self) -> bool {
+        matches!(self, PointType::OnCurve { .. })
+    }
+
+    pub fn is_smooth(&self) -> bool {
+        matches!(self, PointType::OnCurve { smooth: true })
+    }
+}
+
+impl SplinePoint {
+    fn on_curve(point: Point, smooth: bool) -> SplinePoint {
+        SplinePoint {
+            point,
+            type_: PointType::OnCurve { smooth },
+            id: PointId::next(),
+        }
+    }
+
+    pub fn control(point: Point, auto: bool) -> SplinePoint {
+        SplinePoint {
+            point,
+            type_: PointType::Control { auto },
+            id: PointId::next(),
+        }
+    }
+    pub fn is_auto(&self) -> bool {
+        self.type_.is_auto()
+    }
+
+    pub fn is_control(&self) -> bool {
+        self.type_.is_control()
+    }
+
+    pub fn is_on_curve(&self) -> bool {
+        self.type_.is_on_curve()
+    }
+
+    pub fn is_smooth(&self) -> bool {
+        self.type_.is_smooth()
+    }
+
+    pub fn toggle_type(&mut self) {
+        match &mut self.type_ {
+            PointType::OnCurve { smooth } => *smooth = !*smooth,
+            PointType::Control { auto } => *auto = !*auto,
+        }
+    }
+}
+
+impl Default for Path {
+    fn default() -> Self {
+        Path {
+            points: Arc::new(Vec::new()),
+            bezier: Arc::new(BezPath::default()),
+            solver: SplineSpec::new(),
+            trailing: None,
+            closed: false,
+        }
+    }
+}
+
+impl Path {
+    pub fn new() -> Path {
+        Path::default()
+        //Path::debug()
+    }
+
+    //fn debug() -> Path {
+    //let mut path = Path::default();
+    //path.move_to((100., 100.), false);
+    //path.spline_to((200., 150.), false);
+    //path.line_to((50., 200.0), true);
+    //path.line_to((250.0, 250.0), false);
+    //path.spline_to((300., 300.0), false);
+    //path.after_change();
+    //path
+    //}
+
+    pub fn points(&self) -> &[SplinePoint] {
+        &self.points
+    }
+
+    pub fn bezier(&self) -> &BezPath {
+        &self.bezier
+    }
+
+    pub fn trailing(&self) -> Option<Point> {
+        self.trailing
+    }
+
+    pub fn closed(&self) -> bool {
+        self.closed
+    }
+
+    pub fn solver(&self) -> &SplineSpec {
+        &self.solver
+    }
+
+    fn points_mut(&mut self) -> &mut Vec<SplinePoint> {
+        Arc::make_mut(&mut self.points)
+    }
+
+    pub fn add_point(&mut self, point: Point, smooth: bool) -> PointId {
+        if self.points.is_empty() {
+            self.move_to(point, smooth);
+        } else if !smooth && self.trailing.is_none() {
+            self.line_to(point, smooth);
+        } else {
+            self.spline_to(point, smooth);
+        }
+        self.after_change();
+        self.trailing = None;
+        self.points().last().map(|pt| pt.id).unwrap()
+    }
+
+    fn move_to(&mut self, point: impl Into<Point>, smooth: bool) {
+        let point = point.into();
+        self.points_mut().push(SplinePoint::on_curve(point, smooth));
+        self.solver.move_to(point);
+    }
+
+    fn line_to(&mut self, point: impl Into<Point>, smooth: bool) {
+        let point = point.into();
+        self.points_mut().push(SplinePoint::on_curve(point, smooth));
+        self.solver.line_to(point, smooth);
+    }
+
+    fn spline_to(&mut self, p3: impl Into<Point>, smooth: bool) {
+        let p3 = p3.into();
+        let prev = self.points().last().cloned().unwrap();
+        let (p1, auto) = match self.trailing.take() {
+            Some(pt) => (pt, false),
+            None => (p3.lerp(prev.point, 1.0 / 3.0), true),
+        };
+        let p2 = p3.lerp(prev.point, 2.0 / 3.0);
+        self.points_mut().push(SplinePoint::control(p1, auto));
+        self.points_mut().push(SplinePoint::control(p2, true));
+        self.points_mut().push(SplinePoint::on_curve(p3, smooth));
+        // for the solver, convert auto to Option
+        let p1 = if auto { None } else { Some(p1) };
+        self.solver.spline_to(p1, None, p3, smooth);
+    }
+
+    pub fn remove_last_segment(&mut self) -> Option<PointId> {
+        Arc::make_mut(&mut self.points).pop();
+        while self
+            .points()
+            .last()
+            .map(|pt| pt.type_.is_control())
+            .unwrap_or(false)
+        {
+            Arc::make_mut(&mut self.points).pop();
+        }
+        self.solver.elements_mut().pop();
+        self.trailing = None;
+        self.after_change();
+        self.points().last().map(|pt| pt.id)
+    }
+
+    pub fn close(&mut self) {
+        if !self.closed && self.points.len() > 2 {
+            let first = self.points.first().cloned().unwrap();
+            self.spline_to(first.point, true);
+            self.closed = true;
+            self.solver.close();
+        }
+    }
+
+    pub fn update_for_drag(&mut self, handle: Point) {
+        assert!(!self.points.is_empty());
+        if self.points.len() > 1 && !self.last_segment_is_curve() {
+            self.convert_last_to_curve();
+        }
+        self.update_trailing(handle);
+        self.after_change();
+    }
+
+    pub fn move_point(&mut self, id: PointId, new_point: Point) {
+        let pos = self.idx_for_point(id).unwrap();
+        let point = self.points_mut().get_mut(pos).unwrap();
+        point.point = new_point;
+        if point.is_auto() {
+            point.toggle_type();
+        }
+
+        let (elem, idx) = self.element_containing_idx_mut(pos);
+        match elem {
+            Element::MoveTo(pt) | Element::LineTo(pt, _) => *pt = new_point,
+            Element::SplineTo(p1, p2, p3, _) => match idx {
+                0 => *p1 = Some(new_point),
+                1 => *p2 = Some(new_point),
+                2 => *p3 = new_point,
+                _ => unreachable!(),
+            },
+        }
+        self.after_change();
+        //FIXME: if we're smooth, and the opposite handle is non-auto, we should
+        //update that handle as well?
+    }
+
+    /// If this is an on-curve point, toggle its smoothness
+    pub fn toggle_point_type(&mut self, id: PointId) {
+        let pos = self
+            .idx_for_point(id)
+            .expect("selected point always exists");
+        let pt = self.points.get(pos).unwrap();
+
+        let new_auto = match pt.type_ {
+            PointType::Control { auto: true } => Some(pt.point),
+            _ => None,
+        };
+
+        self.points_mut().get_mut(pos).unwrap().toggle_type();
+        let (elem, idx) = self.element_containing_idx_mut(pos);
+        match elem {
+            Element::LineTo(_, smooth) => *smooth = !*smooth,
+            Element::SplineTo(p1, p2, _, smooth) => match idx {
+                0 => *p1 = new_auto,
+                1 => *p2 = new_auto,
+                2 => *smooth = !*smooth,
+                _ => (),
+            },
+            _ => (),
+        }
+        self.after_change();
+    }
+
+    /// Given an index into our points array, returns the spline element
+    /// containing that index, as well as the position within that element
+    /// of the point in question.
+    fn element_containing_idx_mut(&mut self, idx: usize) -> (&mut Element, usize) {
+        let mut dist_to_pt = idx;
+        for element in self.solver.elements_mut().iter_mut() {
+            match element {
+                Element::MoveTo(..) | Element::LineTo(..) if dist_to_pt == 0 => {
+                    return (element, 0)
+                }
+                Element::LineTo(..) | Element::MoveTo(..) => dist_to_pt -= 1,
+                Element::SplineTo(..) if (0..=2).contains(&dist_to_pt) => {
+                    return (element, dist_to_pt)
+                }
+                Element::SplineTo(..) => dist_to_pt = dist_to_pt.saturating_sub(3),
+            }
+        }
+        unreachable!();
+    }
+
+    pub fn maybe_convert_line_to_spline(&mut self, click: Point, max_dist: f64) {
+        let mut best = (f64::MAX, 0);
+        let spline = self.solver.solve();
+        for (i, seg) in spline.segments().iter().enumerate() {
+            if !seg.is_line() {
+                continue;
+            }
+            let line = Line::new(seg.p0, seg.p3);
+            let closest = line.nearest(click, 0.1).1.sqrt();
+            if closest < best.0 {
+                best = (closest, i)
+            }
+        }
+
+        if best.0 > max_dist {
+            return;
+        }
+
+        // insert two auto points:
+        let mut prev_point = self.points().first().unwrap().point;
+        let mut segs_seen = 0;
+        //let insert;
+        for (i, pt) in self.points().iter().enumerate().skip(1) {
+            if pt.is_control() {
+                continue;
+            }
+            if segs_seen == best.1 {
+                let p1 = prev_point.lerp(pt.point, 1.0 / 3.0);
+                let p2 = prev_point.lerp(pt.point, 2.0 / 3.0);
+                self.points_mut().insert(i, SplinePoint::control(p1, true));
+                self.points_mut().insert(i, SplinePoint::control(p2, true));
+                break;
+            }
+            segs_seen += 1;
+            prev_point = pt.point;
+        }
+
+        // and convert the appropriate solver element to be a splineto:
+        let new_el = self.solver.elements().get(best.1 + 1).and_then(|el| {
+            if let Element::LineTo(p1, smooth) = el {
+                Some(Element::SplineTo(None, None, *p1, *smooth))
+            } else {
+                None
+            }
+        });
+        if let Some(new_el) = new_el {
+            self.solver.elements_mut()[best.1 + 1] = new_el;
+        } else {
+            eprintln!(
+                "failed to update element after line->spline conversion: {:?}",
+                self.solver.elements().get(best.1)
+            );
+        }
+        self.after_change();
+    }
+
+    fn after_change(&mut self) {
+        if self.points.len() > 1 {
+            self.rebuild_spline()
+        } else {
+            self.bezier = Arc::new(BezPath::default());
+        }
+    }
+
+    fn idx_for_point(&self, id: PointId) -> Option<usize> {
+        self.points.iter().position(|pt| pt.id == id)
+    }
+
+    fn rebuild_spline(&mut self) {
+        let Path { solver, points, .. } = self;
+        let spline = solver.solve();
+        let points = Arc::make_mut(points);
+        let mut ix = 1;
+        for segment in spline.segments() {
+            if segment.is_line() {
+                // I think we do no touchup, here?
+                match points.get(ix).map(|pt| pt.type_) {
+                    Some(PointType::OnCurve { .. }) => {
+                        // expected case
+                        ix += 1;
+                    }
+                    Some(PointType::Control { .. }) => {
+                        eprintln!(
+                            "segment is line but control points exist, we should delete them?"
+                        );
+                        ix += 3;
+                    }
+                    None => panic!("missing point at idx {}"),
+                };
+            } else {
+                let p1 = points.get_mut(ix).unwrap();
+                if matches!(p1.type_, PointType::Control { auto: true }) {
+                    p1.point = segment.p1;
+                }
+                let p2 = points.get_mut(ix + 1).unwrap();
+                if matches!(p2.type_, PointType::Control { auto: true }) {
+                    p2.point = segment.p2;
+                }
+                ix += 3;
+            }
+        }
+
+        self.bezier = Arc::new(spline.render());
+
+        // and then we want to actually update our stored points:
+    }
+
+    //fn iter_spline_ops(&self) -> impl Iterator<Item = SplineOp> {
+    //SplineOpIter {
+    //points: self.points.clone(),
+    //ix: 0,
+    //}
+    //}
+
+    fn last_segment_is_curve(&self) -> bool {
+        let len = self.points.len();
+        len > 2 && matches!(self.points[len - 2].type_, PointType::Control { .. })
+    }
+
+    fn convert_last_to_curve(&mut self) {
+        if let Some(prev_point) = self.points_mut().pop() {
+            assert!(self.trailing.is_none());
+            self.solver.elements_mut().pop();
+            self.spline_to(prev_point.point, true);
+        }
+    }
+
+    /// Update the curve while the user drags a new control point.
+    fn update_trailing(&mut self, handle: Point) {
+        if self.points.len() > 1 {
+            let len = self.points.len();
+            assert!(matches!(self.points[len - 1].type_, PointType::OnCurve { .. }));
+            assert!(matches!(self.points[len - 2].type_, PointType::Control { .. }));
+            let on_curve_pt = self.points[len - 1].point;
+            let new_p = on_curve_pt - (handle - on_curve_pt);
+            self.points_mut()[len - 2].point = new_p;
+            self.points_mut()[len - 2].type_ = PointType::Control { auto: false };
+            let last_el = self.solver.elements_mut().last_mut().unwrap();
+            if let Element::SplineTo(_, p2, _, _) = last_el {
+                *p2 = Some(new_p);
+            } else {
+                panic!("unexpected element {:?}", last_el);
+            }
+        }
+        self.trailing = Some(handle);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SplineOp {
+    MoveTo(Point),
+    LineTo(Point, bool),
+    SplineTo(Option<Point>, Option<Point>, Point, bool),
+}
+
+struct SplineOpIter {
+    points: Arc<Vec<SplinePoint>>,
+    ix: usize,
+}
+
+impl Iterator for SplineOpIter {
+    type Item = SplineOp;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.ix == self.points.len() {
+            return None;
+        }
+
+        let next_pt = self.points[self.ix];
+        match next_pt.type_ {
+            PointType::OnCurve { smooth } => {
+                self.ix += 1;
+                if self.ix == 1 {
+                    Some(SplineOp::MoveTo(self.points[self.ix - 1].point))
+                } else {
+                    Some(SplineOp::LineTo(next_pt.point, smooth))
+                }
+            }
+            PointType::Control { auto } => {
+                let p1 = if auto { None } else { Some(next_pt.point) };
+                let p2 = self
+                    .points
+                    .get(self.ix + 1)
+                    .map(|pt| match pt.type_ {
+                        PointType::Control { auto: true } => None,
+                        PointType::Control { auto: false } => Some(pt.point),
+                        _ => panic!("missing offcurve point"),
+                    })
+                    .unwrap();
+                let p3 = self.points[self.ix + 2];
+                let smooth = match p3.type_ {
+                    PointType::OnCurve { smooth } => smooth,
+                    _ => panic!("missing on curve point"),
+                };
+                self.ix += 3;
+                Some(SplineOp::SplineTo(p1, p2, p3.point, smooth))
+            }
+        }
+    }
+}

--- a/splinetoy/src/path.rs
+++ b/splinetoy/src/path.rs
@@ -137,6 +137,10 @@ impl Path {
     //path
     //}
 
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
+
     pub fn points(&self) -> &[SplinePoint] {
         &self.points
     }

--- a/splinetoy/src/pen.rs
+++ b/splinetoy/src/pen.rs
@@ -1,0 +1,99 @@
+//! The bezier pen tool.
+
+use druid::{EventCtx, KbKey, KeyEvent, MouseEvent};
+
+use crate::{
+    edit_session::EditSession,
+    mouse::{Drag, Mouse, MouseDelegate, TaggedEvent},
+    //path::Path,
+    tools::{EditType, Tool, ToolId},
+};
+
+pub const TOOL_NAME: &str = "Pen";
+
+/// The state of the pen.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct Pen {
+    //is_draggable: bool,
+}
+
+impl MouseDelegate<EditSession> for Pen {
+    fn cancel(&mut self, _data: &mut EditSession) {}
+
+    fn left_down(&mut self, event: &MouseEvent, data: &mut EditSession) {
+        //self.is_draggable = false;
+        //let vport = data.viewport;
+        if event.count == 1 {
+            let smooth = event.mods.alt();
+            data.add_point(event.pos, smooth);
+        } else if event.count == 2 {
+        }
+    }
+
+    fn left_up(&mut self, _event: &MouseEvent, _data: &mut EditSession) {
+        //if let Some(path) = data.active_path_mut() {
+        //if path.is_closed() || path.points().len() > 1 && !path.last_segment_is_curve() {
+        //path.clear_trailing();
+        //}
+        //}
+    }
+
+    fn left_drag_changed(&mut self, drag: Drag, data: &mut EditSession) {
+        //if !self.is_draggable {
+        //return;
+        //}
+        let Drag { current, .. } = drag;
+        data.update_for_drag(current.pos);
+        //self.this_edit_type = Some(EditType::Drag);
+    }
+
+    fn left_drag_ended(&mut self, _: Drag, _: &mut EditSession) {
+        // TODO: this logic needs rework. A click-drag sequence should be a single
+        // undo group.
+        //self.this_edit_type = Some(EditType::DragUp);
+    }
+}
+
+impl Tool for Pen {
+    fn mouse_event(
+        &mut self,
+        event: TaggedEvent,
+        mouse: &mut Mouse,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        if matches!(&event, TaggedEvent::Down(_)) {
+            ctx.set_active(true);
+        }
+        if matches!(&event, TaggedEvent::Up(m) if m.buttons.is_empty()) {
+            ctx.set_active(false);
+        }
+        mouse.mouse_event(event, data, self);
+        None
+        //self.this_edit_type.take()
+    }
+
+    fn key_down(
+        &mut self,
+        event: &KeyEvent,
+        _ctx: &mut EventCtx,
+        _data: &mut EditSession,
+    ) -> Option<EditType> {
+        //assert!(self.this_edit_type.is_none());
+        match event {
+            e if e.key == KbKey::Backspace => {
+                //data.delete_selection();
+                //self.this_edit_type = Some(EditType::Normal);
+            }
+            // TODO: should support nudging; basically a lot of this should
+            // be shared with selection.
+            _ => return None,
+        }
+        None
+        //self.this_edit_type.take()
+    }
+
+    fn name(&self) -> ToolId {
+        TOOL_NAME
+    }
+}

--- a/splinetoy/src/pen.rs
+++ b/splinetoy/src/pen.rs
@@ -23,7 +23,7 @@ impl MouseDelegate<EditSession> for Pen {
     fn left_down(&mut self, event: &MouseEvent, data: &mut EditSession) {
         if event.count == 1 {
             let smooth = event.mods.alt();
-            let point = match data.path.points().last() {
+            let point = match data.active_path().points().last() {
                 Some(prev) if event.mods.shift() => tools::axis_locked_point(event.pos, prev.point),
                 _ => event.pos,
             };

--- a/splinetoy/src/select.rs
+++ b/splinetoy/src/select.rs
@@ -1,7 +1,7 @@
 use druid::{EventCtx, KbKey, KeyEvent, MouseEvent};
 
 use crate::mouse::{Drag, Mouse, MouseDelegate, TaggedEvent};
-use crate::tools::{EditType, Tool, ToolId};
+use crate::tools::{self, EditType, Tool, ToolId};
 use crate::{edit_session::EditSession, path::PointId};
 
 pub const TOOL_NAME: &str = "Select";
@@ -98,7 +98,13 @@ impl MouseDelegate<EditSession> for Select {
 
     fn left_drag_changed(&mut self, drag: Drag, data: &mut EditSession) {
         if let DragState::MovePoint(id) = self.drag {
-            data.move_point(id, drag.current.pos);
+            let Drag { start, current, .. } = drag;
+            let point = if current.mods.shift() {
+                tools::axis_locked_point(current.pos, start.pos)
+            } else {
+                current.pos
+            };
+            data.move_point(id, point);
         }
     }
 

--- a/splinetoy/src/select.rs
+++ b/splinetoy/src/select.rs
@@ -1,0 +1,113 @@
+use druid::{EventCtx, MouseEvent};
+
+use crate::mouse::{Drag, Mouse, MouseDelegate, TaggedEvent};
+use crate::tools::{EditType, Tool, ToolId};
+use crate::{edit_session::EditSession, path::PointId};
+
+pub const TOOL_NAME: &str = "Select";
+
+/// A set of states that are possible while handling a mouse drag.
+#[derive(Debug, Clone)]
+enum DragState {
+    /// State for a drag that is moving an off-curve point.
+    MovePoint(PointId),
+    ///// State if some earlier gesture consumed the mouse-down, and we should not
+    ///// recognize a drag.
+    //Suppress,
+    None,
+}
+
+/// The state of the selection tool.
+#[derive(Debug, Default, Clone)]
+pub struct Select {
+    /// the state preserved between drag events.
+    drag: DragState,
+    //last_pos: Point,
+    /// The edit type produced by the current event, if any.
+    ///
+    /// This is stashed here because we can't return anything from the methods in
+    /// `MouseDelegate`.
+    ///
+    /// It is an invariant that this is always `None`, except while we are in
+    /// a `key_down`, `key_up`, or `mouse_event` method.
+    this_edit_type: Option<EditType>,
+}
+
+impl Tool for Select {
+    fn mouse_event(
+        &mut self,
+        event: TaggedEvent,
+        mouse: &mut Mouse,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        assert!(self.this_edit_type.is_none());
+        if matches!(&event, TaggedEvent::Down(_)) {
+            ctx.set_active(true);
+        }
+        if matches!(&event, TaggedEvent::Up(m) if m.buttons.is_empty()) {
+            ctx.set_active(false);
+        }
+        mouse.mouse_event(event, data, self);
+        self.this_edit_type.take()
+    }
+
+    fn name(&self) -> ToolId {
+        "Select"
+    }
+}
+
+impl MouseDelegate<EditSession> for Select {
+    fn left_down(&mut self, event: &MouseEvent, data: &mut EditSession) {
+        assert!(matches!(self.drag, DragState::None));
+        if event.count == 1 {
+            let point = data.hit_test_points(event.pos, None);
+            data.set_selection(point);
+            if point.is_none() && event.mods.alt() {
+                // see if we clicked a line?
+                data.maybe_convert_line_to_spline(event.pos);
+            }
+        } else if event.count == 2 {
+            data.toggle_selected_point_type();
+        }
+    }
+
+    fn left_up(&mut self, _event: &MouseEvent, _data: &mut EditSession) {
+        self.drag = DragState::None;
+    }
+
+    fn left_drag_began(&mut self, drag: Drag, data: &mut EditSession) {
+        if let Some(pt) = data.selected_point() {
+            self.drag = DragState::MovePoint(pt.id);
+            data.move_point(pt.id, drag.current.pos);
+        }
+    }
+
+    fn left_drag_changed(&mut self, drag: Drag, data: &mut EditSession) {
+        if let DragState::MovePoint(id) = self.drag {
+            data.move_point(id, drag.current.pos);
+        }
+    }
+
+    fn left_drag_ended(&mut self, _drag: Drag, _data: &mut EditSession) {
+        if self.drag.is_move() {
+            self.this_edit_type = Some(EditType::DragUp);
+        }
+    }
+
+    fn cancel(&mut self, _data: &mut EditSession) {
+        self.drag = DragState::None
+    }
+}
+
+impl Default for DragState {
+    fn default() -> Self {
+        DragState::None
+    }
+}
+
+impl DragState {
+    fn is_move(&self) -> bool {
+        matches!(self, DragState::MovePoint(_))
+    }
+}

--- a/splinetoy/src/select.rs
+++ b/splinetoy/src/select.rs
@@ -1,4 +1,4 @@
-use druid::{EventCtx, MouseEvent};
+use druid::{EventCtx, KbKey, KeyEvent, MouseEvent};
 
 use crate::mouse::{Drag, Mouse, MouseDelegate, TaggedEvent};
 use crate::tools::{EditType, Tool, ToolId};
@@ -34,6 +34,19 @@ pub struct Select {
 }
 
 impl Tool for Select {
+    fn key_down(
+        &mut self,
+        key: &KeyEvent,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        if key.key == KbKey::Backspace {
+            data.delete();
+            ctx.set_handled();
+        }
+        None
+    }
+
     fn mouse_event(
         &mut self,
         event: TaggedEvent,

--- a/splinetoy/src/toolbar.rs
+++ b/splinetoy/src/toolbar.rs
@@ -1,0 +1,278 @@
+//! The toolbar widget
+
+use druid::kurbo::{Affine, BezPath, Circle, Line, Shape, Vec2};
+use druid::widget::prelude::*;
+use druid::widget::{Painter, WidgetExt};
+use druid::{Color, Data, HotKey, KeyEvent, Rect, Selector, SysMods, WidgetPod};
+
+//use crate::consts;
+use crate::tools::ToolId;
+
+const TOOLBAR_ITEM_SIZE: Size = Size::new(40.0, 40.0);
+const TOOLBAR_ITEM_PADDING: f64 = 2.0;
+const TOOLBAR_ICON_PADDING: f64 = 5.0;
+const TOOLBAR_BORDER_STROKE_WIDTH: f64 = 2.0;
+const TOOLBAR_ITEM_STROKE_WIDTH: f64 = 1.5;
+// TODO: move these to theme
+const TOOLBAR_BG_DEFAULT: Color = Color::grey8(0xDD);
+const TOOLBAR_BG_SELECTED: Color = Color::grey8(0xAD);
+
+pub const SET_TOOL: Selector<ToolId> = Selector::new("spline-toy.set-tool");
+
+struct ToolbarItem {
+    icon: BezPath,
+    name: ToolId,
+    hotkey: HotKey,
+}
+
+/// The floating toolbar.
+///
+/// This is a very hacky implementation to get us rolling; it is not very
+/// reusable, but can be refactored at a future date.
+pub struct Toolbar {
+    items: Vec<ToolbarItem>,
+    selected: usize,
+    widgets: Vec<WidgetPod<bool, Box<dyn Widget<bool>>>>,
+}
+
+/// A wrapper around control UI elements, drawing a drop shadow & rounded rect
+pub struct FloatingPanel<W> {
+    hide_panel: bool,
+    inner: W,
+}
+
+impl Toolbar {
+    fn new(items: Vec<ToolbarItem>) -> Self {
+        let mut widgets = Vec::with_capacity(items.capacity());
+        for icon in items.iter().map(|item| item.icon.clone()) {
+            let widg = Painter::new(move |ctx, is_selected: &bool, _| {
+                let color = if *is_selected {
+                    TOOLBAR_BG_SELECTED
+                } else {
+                    TOOLBAR_BG_DEFAULT
+                };
+                let frame = ctx.size().to_rect();
+                ctx.fill(frame, &color);
+                ctx.fill(&icon, &Color::WHITE);
+                ctx.stroke(&icon, &Color::BLACK, TOOLBAR_ITEM_STROKE_WIDTH);
+            });
+
+            let widg = widg.on_click(|ctx, selected, _| {
+                *selected = true;
+                ctx.request_paint();
+            });
+            widgets.push(WidgetPod::new(widg.boxed()));
+        }
+
+        Toolbar {
+            items,
+            widgets,
+            selected: 0,
+        }
+    }
+
+    pub fn tool_for_keypress(&self, key: &KeyEvent) -> Option<ToolId> {
+        self.items
+            .iter()
+            .find(|tool| tool.hotkey.matches(key))
+            .map(|tool| tool.name)
+    }
+}
+
+impl<T: Data> Widget<T> for Toolbar {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut T, env: &Env) {
+        if let Event::Command(cmd) = event {
+            if let Some(tool_id) = cmd.get(SET_TOOL) {
+                let sel = self.items.iter().position(|item| item.name == *tool_id);
+                self.selected = sel.unwrap_or(self.selected);
+                ctx.request_paint();
+            }
+        }
+
+        for (i, child) in self.widgets.iter_mut().enumerate() {
+            let mut is_selected = i == self.selected;
+            child.event(ctx, event, &mut is_selected, env);
+
+            if is_selected && i != self.selected {
+                let tool = self.items[i].name;
+                ctx.submit_command(SET_TOOL.with(tool));
+            }
+        }
+
+        // if there's a click here we don't want to pass it down to the child
+        if matches!(event, Event::MouseDown(_) | Event::MouseUp(_)) {
+            ctx.set_handled();
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &T, env: &Env) {
+        for (i, child) in self.widgets.iter_mut().enumerate() {
+            let is_selected = i == self.selected;
+            child.lifecycle(ctx, event, &is_selected, env);
+        }
+    }
+
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {
+        //todo!()
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &T, env: &Env) -> Size {
+        let constraints = BoxConstraints::tight(TOOLBAR_ITEM_SIZE);
+        let mut x_pos = 0.0;
+
+        for child in self.widgets.iter_mut() {
+            // data doesn't matter here
+            let size = child.layout(ctx, &constraints, &false, env);
+            child.set_layout_rect(ctx, &false, env, Rect::from_origin_size((x_pos, 0.0), size));
+            x_pos += TOOLBAR_ITEM_SIZE.width + TOOLBAR_ITEM_PADDING;
+        }
+
+        // Size doesn't account for stroke etc
+        bc.constrain(Size::new(
+            x_pos - TOOLBAR_ITEM_PADDING,
+            TOOLBAR_ITEM_SIZE.height,
+        ))
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, env: &Env) {
+        for (i, child) in self.widgets.iter_mut().enumerate() {
+            let is_selected = i == self.selected;
+            child.paint(ctx, &is_selected, env);
+        }
+
+        let stroke_inset = TOOLBAR_BORDER_STROKE_WIDTH / 2.0;
+        for child in self.widgets.iter().skip(1) {
+            let child_frame = child.layout_rect();
+            let line = Line::new(
+                (child_frame.min_x() - stroke_inset, child_frame.min_y()),
+                (child_frame.min_x() - stroke_inset, child_frame.max_y()),
+            );
+            ctx.stroke(line, &Color::BLACK, TOOLBAR_BORDER_STROKE_WIDTH);
+        }
+    }
+}
+
+impl<W> FloatingPanel<W> {
+    pub fn new(inner: W) -> Self {
+        FloatingPanel {
+            hide_panel: false,
+            inner,
+        }
+    }
+
+    /// return a reference to the inner widget.
+    pub fn inner(&self) -> &W {
+        &self.inner
+    }
+}
+
+impl<T: Data, W: Widget<T>> Widget<T> for FloatingPanel<W> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        self.inner.event(ctx, event, data, env);
+        //if let Event::Command(cmd) = event {
+        //if let Some(in_temporary_preview) = cmd.get(consts::cmd::TOGGLE_PREVIEW_TOOL) {
+        //self.hide_panel = *in_temporary_preview;
+        //ctx.request_paint();
+        //}
+        //}
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.inner.lifecycle(ctx, event, data, env);
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        self.inner.update(ctx, old_data, data, env);
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        let size = self.inner.layout(ctx, bc, data, env);
+        ctx.set_paint_insets((0., 6.0, 6.0, 0.));
+        size
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        if self.hide_panel {
+            return;
+        }
+        let frame = ctx.size().to_rect();
+        ctx.blurred_rect(frame + Vec2::new(2.0, 2.0), 4.0, &Color::grey(0.5));
+        let rounded = frame.to_rounded_rect(5.0);
+        ctx.fill(rounded, &TOOLBAR_BG_DEFAULT);
+        ctx.with_save(|ctx| {
+            ctx.clip(rounded);
+            self.inner.paint(ctx, data, env);
+        });
+        ctx.stroke(rounded, &Color::BLACK, TOOLBAR_BORDER_STROKE_WIDTH);
+    }
+}
+
+impl Default for Toolbar {
+    fn default() -> Self {
+        let select = ToolbarItem {
+            name: "Select",
+            icon: constrain_path(select_path()),
+            hotkey: HotKey::new(None, "v"),
+        };
+
+        let pen = ToolbarItem {
+            name: "Pen",
+            icon: constrain_path(pen_path()),
+            hotkey: HotKey::new(None, "p"),
+        };
+        Toolbar::new(vec![select, pen])
+    }
+}
+
+fn constrain_path(mut path: BezPath) -> BezPath {
+    let path_size = path.bounding_box().size();
+    let icon_size = TOOLBAR_ITEM_SIZE.max_side() - TOOLBAR_ICON_PADDING * 2.0;
+    let scale = icon_size / path_size.max_side();
+    path.apply_affine(Affine::scale(scale));
+    let center_offset = (TOOLBAR_ITEM_SIZE - (path_size * scale)).to_vec2() / 2.0;
+    path.apply_affine(Affine::translate(center_offset));
+    path
+}
+
+fn select_path() -> BezPath {
+    let mut bez = BezPath::new();
+
+    bez.move_to((111.0, 483.0));
+    bez.line_to((202.0, 483.0));
+    bez.line_to((202.0, 328.0));
+    bez.line_to((312.0, 361.0));
+    bez.line_to((156.0, 0.0));
+    bez.line_to((0.0, 360.0));
+    bez.line_to((111.0, 330.0));
+    bez.line_to((111.0, 483.0));
+    bez.close_path();
+
+    bez.apply_affine(Affine::rotate(-0.5));
+    let origin = bez.bounding_box().origin();
+    bez.apply_affine(Affine::translate(-origin.to_vec2()));
+    bez
+}
+
+fn pen_path() -> BezPath {
+    let mut bez = BezPath::new();
+
+    bez.move_to((97.0, 0.0));
+    bez.line_to((214.0, 0.0));
+    bez.line_to((273.0, 241.0));
+    bez.line_to((315.0, 321.0));
+    bez.line_to((260.0, 438.0));
+    bez.line_to((260.0, 621.0));
+    bez.line_to((50.0, 621.0));
+    bez.line_to((50.0, 438.0));
+    bez.line_to((0.0, 321.0));
+    bez.line_to((45.0, 241.0));
+    bez.line_to((97.0, 0.0));
+    bez.close_path();
+
+    bez.move_to((155.0, 311.0));
+    bez.line_to((155.0, 0.0));
+    bez.close_path();
+    let circle = Circle::new((155.0, 361.0), 50.0);
+    bez.extend(circle.path_elements(0.1));
+    bez
+}

--- a/splinetoy/src/toolbar.rs
+++ b/splinetoy/src/toolbar.rs
@@ -3,9 +3,8 @@
 use druid::kurbo::{Affine, BezPath, Circle, Line, Shape, Vec2};
 use druid::widget::prelude::*;
 use druid::widget::{Painter, WidgetExt};
-use druid::{Color, Data, HotKey, KeyEvent, Rect, Selector, SysMods, WidgetPod};
+use druid::{Color, Cursor, Data, HotKey, KeyEvent, Rect, Selector, WidgetPod};
 
-//use crate::consts;
 use crate::tools::ToolId;
 
 const TOOLBAR_ITEM_SIZE: Size = Size::new(40.0, 40.0);
@@ -81,6 +80,9 @@ impl Toolbar {
 
 impl<T: Data> Widget<T> for Toolbar {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut T, env: &Env) {
+        if let Event::WindowConnected = event {
+            ctx.set_cursor(&Cursor::Arrow)
+        }
         if let Event::Command(cmd) = event {
             if let Some(tool_id) = cmd.get(SET_TOOL) {
                 let sel = self.items.iter().position(|item| item.name == *tool_id);

--- a/splinetoy/src/tools.rs
+++ b/splinetoy/src/tools.rs
@@ -138,7 +138,7 @@ pub fn tool_for_id(id: ToolId) -> Option<Box<dyn Tool>> {
 
 /// Lock the smallest axis of `point` (from `prev`) to that axis on `prev`.
 /// (aka shift + click)
-fn axis_locked_point(point: Point, prev: Point) -> Point {
+pub(crate) fn axis_locked_point(point: Point, prev: Point) -> Point {
     let dxy = prev - point;
     if dxy.x.abs() > dxy.y.abs() {
         Point::new(point.x, prev.y)

--- a/splinetoy/src/tools.rs
+++ b/splinetoy/src/tools.rs
@@ -1,0 +1,148 @@
+//! A tool accepts user input and modifies the canvas.
+
+use druid::{kurbo::Point, Cursor};
+use druid::{Env, EventCtx, KeyEvent, PaintCtx};
+
+use crate::edit_session::EditSession;
+use crate::mouse::{Mouse, TaggedEvent};
+//use crate::path::Path;
+use crate::pen::Pen;
+use crate::select::Select;
+
+/// Something to pass around instead of a Box<dyn Tool>
+pub type ToolId = &'static str;
+//pub type EditSession = Path;
+
+/// Types of state modifications, for the purposes of undo.
+///
+/// Certain state modifications group together in undo; for instance when dragging
+/// a point, each individual edit (each time we receive a `MouseMouved`` event)
+/// is combined into a single edit representing the entire drag.
+///
+/// When a `Tool` handles an event, it returns an `Option<EditType>`, that describes
+/// what (if any) sort of modification it made to the state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditType {
+    /// Any change that always gets its own undo group
+    //Normal,
+    //NudgeLeft,
+    //NudgeRight,
+    //NudgeUp,
+    //NudgeDown,
+    ///// An edit where a drag of some kind is in progress.
+    //Drag,
+    ///// An edit that finishes a drag; it combines with the previous undo
+    /// group, but not with any subsequent event.
+    DragUp,
+}
+
+/// A trait for representing the logic of a tool; that is, something that handles
+/// mouse and keyboard events, and modifies the current [`EditSession`].
+pub trait Tool {
+    /// Called once per `paint()` call in the editor widget, this gives tools
+    /// an opportunity to draw on the canvas.
+    ///
+    /// As an example, the `Select` (arrow) widget uses this to paint the current
+    /// selection rectangle, if a drag gesture is in progress.
+    ///
+    /// # Note:
+    ///
+    /// When drawing, coordinates in 'design space' may need to be converted to
+    /// 'screen space'; conversion methods are available via the [`ViewPort`]
+    /// at `data.viewport`.
+    ///
+    /// [`EditSession`]: struct.EditSession.html
+    /// [`ViewPort`]: struct.ViewPort.html
+    #[allow(unused)]
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &EditSession, env: &Env) {}
+    /// Called on each key_down event in the parent.
+    #[allow(unused)]
+    fn key_down(
+        &mut self,
+        key: &KeyEvent,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        None
+    }
+    /// Called on each key_up event in the parent.
+    #[allow(unused)]
+    fn key_up(
+        &mut self,
+        key: &KeyEvent,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        None
+    }
+
+    /// Called whenever a tool is first activated, so that it can access or modify
+    /// mouse settings.
+    #[allow(unused)]
+    fn init_mouse(&mut self, mouse: &mut Mouse) {}
+
+    /// Called with each mouse event. The `mouse` argument is a reference to a [`Mouse`]
+    /// struct that is shared between all tools; a particular `Tool` can implement the
+    /// [`MouseDelegate`] trait and pass the events to `Mouse` instance.
+    ///
+    /// [`Mouse`]: struct.Mouse.html
+    /// [`MouseDelegate`]: ../mouse/trait.MouseDelegate.html
+    #[allow(unused)]
+    fn mouse_event(
+        &mut self,
+        event: TaggedEvent,
+        mouse: &mut Mouse,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        None
+    }
+
+    fn name(&self) -> ToolId;
+
+    fn preferred_cursor(&self) -> Cursor {
+        match self.name() {
+            crate::pen::TOOL_NAME => Cursor::Crosshair,
+            _ => Cursor::Arrow,
+        }
+    }
+}
+
+/// Returns the tool for the given `ToolId`.
+pub fn tool_for_id(id: ToolId) -> Option<Box<dyn Tool>> {
+    match id {
+        //"Preview" => Some(Box::new(Preview::default())),
+        crate::pen::TOOL_NAME => Some(Box::new(Pen::default())),
+        crate::select::TOOL_NAME => Some(Box::new(Select::default())),
+        //"Rectangle" => Some(Box::new(Rectangle::default())),
+        //"Ellipse" => Some(Box::new(Ellipse::default())),
+        //"Knife" => Some(Box::new(Knife::default())),
+        //"Measure" => Some(Box::new(Measure::default())),
+        _ => None,
+    }
+}
+
+//impl EditType {
+//pub fn needs_new_undo_group(self, other: EditType) -> bool {
+//match (self, other) {
+//(EditType::NudgeDown, EditType::NudgeDown) => false,
+//(EditType::NudgeUp, EditType::NudgeUp) => false,
+//(EditType::NudgeLeft, EditType::NudgeLeft) => false,
+//(EditType::NudgeRight, EditType::NudgeRight) => false,
+//(EditType::Drag, EditType::Drag) => false,
+//(EditType::Drag, EditType::DragUp) => false,
+//_ => true,
+//}
+//}
+//}
+
+/// Lock the smallest axis of `point` (from `prev`) to that axis on `prev`.
+/// (aka shift + click)
+fn axis_locked_point(point: Point, prev: Point) -> Point {
+    let dxy = prev - point;
+    if dxy.x.abs() > dxy.y.abs() {
+        Point::new(point.x, prev.y)
+    } else {
+        Point::new(prev.x, point.y)
+    }
+}

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -608,4 +608,12 @@ impl Segment {
             }
         }
     }
+
+    /// Return a [`BezPath`] representing this segment.
+    pub fn to_bezier(&self) -> BezPath {
+        let mut path = BezPath::new();
+        path.move_to(self.p0);
+        self.render(&mut path);
+        path
+    }
 }


### PR DESCRIPTION
This is an initial simple implementation of the UX for the new spline.


This is barebones: there are two tools, 'select' and 'pen', and editing is currently limited to a single subpath. A single point can be manipulated at a time. I've done my best to emulate the behaviour described in https://github.com/linebender/runebender/issues/182, but there are clearly some rough patches & open questions. Deleting off-curve points doesn't work, and probably should; adjusting a handle on a smooth point does not maintain curvature; and I'm sure there are numerous other things.

I would also like to get this working with wasm so that it can be deployed on the web, but that can be a next step.


@raphlinus I'd be curious to hear your thoughts after playing with this a little bit.